### PR TITLE
feat: create k8s lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Vagrant
+.vagrant
+
+# Join Cluster Generated Script
+joincluster.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,121 @@
-# k8s-lab
-A local multi-node Kubernetes cluster perfect for learning
+# Kubernetes Lab
+
+A simple and efficient way to set up a local Kubernetes cluster using Vagrant and VirtualBox. This project creates a multi-node Kubernetes cluster with one control plane and two worker nodes, perfect for development, testing, and learning purposes.
+
+> **Note:** This repository is an excellent resource for preparing for the CKAD (Certified Kubernetes Application Developer) and CKA (Certified Kubernetes Administrator) certifications.
+
+## Features
+
+- Single control plane node and two worker nodes
+- Ubuntu 24.04 LTS as the base operating system
+- Kubernetes 1.32.0
+- Cilium CNI for networking
+- Helm pre-installed on the control plane
+- Automatic cluster initialization and worker node joining
+- Port forwarding for Kubernetes API (6443 -> 16443)
+
+## Prerequisites
+
+- [Vagrant](https://www.vagrantup.com/downloads) (latest version)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (latest version)
+- At least 4GB of RAM (recommended: 8GB+)
+- At least 2 CPU cores (recommended: 4+)
+
+## Quick Start
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/ponceps/k8s-lab.git
+   cd k8s-lab
+   ```
+
+2. Start the cluster:
+   ```bash
+   vagrant up
+   ```
+
+3. Access the control plane:
+   ```bash
+   vagrant ssh controlplane
+   ```
+
+4. Verify the cluster status:
+   ```bash
+   kubectl get nodes
+   ```
+
+## Cluster Configuration
+
+- Control Plane:
+  - Hostname: controlplane
+  - IP: 192.168.56.10
+  - Resources: 2 CPU cores, 2GB RAM
+  - Kubernetes API: 6443 (host port: 16443)
+
+- Worker Nodes:
+  - Hostnames: node01, node02
+  - IPs: 192.168.56.11, 192.168.56.12
+  - Resources: 1 CPU core, 1GB RAM each
+
+## Network Configuration
+
+- Pod Network CIDR: 10.244.0.0/16
+- CNI: Cilium 1.17.2
+- Private Network: 192.168.56.0/24
+
+## Included Components
+
+- Docker container runtime
+- containerd
+- kubeadm, kubelet, and kubectl
+- Helm package manager
+- Cilium CNI plugin
+
+## Usage
+
+### Accessing the Cluster
+
+1. SSH into the control plane:
+   ```bash
+   vagrant ssh controlplane
+   ```
+
+2. Use kubectl to manage the cluster:
+   ```bash
+   kubectl get nodes
+   kubectl get pods -A
+   ```
+
+### Managing the Cluster
+
+- Start the cluster: `vagrant up`
+- Stop the cluster: `vagrant halt`
+- Destroy the cluster: `vagrant destroy`
+- Rebuild the cluster: `vagrant destroy -f && vagrant up`
+
+## Troubleshooting
+
+If you encounter any issues:
+
+1. Check the status of all nodes:
+   ```bash
+   kubectl get nodes
+   ```
+
+2. Check the status of all pods:
+   ```bash
+   kubectl get pods -A
+   ```
+
+3. Check the logs of specific components:
+   ```bash
+   kubectl logs -n kube-system <pod-name>
+   ```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the LICENSE file for details.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+NodeBox = "bento/ubuntu-24.04"
+BASE_IP = "192.168.56"
+CONTROL_PLANE_IP = "#{BASE_IP}.10"
+WORKER_NODES = 2
+
+Vagrant.configure("2") do |config|
+  config.vm.define "controlplane" do |node|
+    node.vm.box = NodeBox
+    node.vm.hostname = "controlplane"
+    node.vm.network "private_network", ip: CONTROL_PLANE_IP
+    node.vm.network "forwarded_port", guest: 6443, host: 16443
+    node.vm.provider "virtualbox" do |vb|
+      vb.name = "controlplane"
+      vb.memory = "2048"
+      vb.cpus = "2"
+    end
+    node.vm.provision "shell", path: "common.sh", args: [CONTROL_PLANE_IP]
+    node.vm.provision "shell", path: "master.sh"
+  end
+
+  (1..WORKER_NODES).each do |i|
+    config.vm.define "node0#{i}" do |node|
+      node.vm.box = NodeBox
+      node.vm.hostname = "node0#{i}"
+      node.vm.network "private_network", ip: "#{BASE_IP}.#{10 + i}"
+      node.vm.provider "virtualbox" do |vb|
+        vb.name = "node0#{i}"
+        vb.memory = "1024"
+        vb.cpus = "1"
+      end
+      node.vm.provision "shell", path: "common.sh", args: [CONTROL_PLANE_IP]
+      node.vm.provision "shell", path: "worker.sh"
+    end
+  end
+end

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+CONTROL_PLANE_IP=$1
+
+##############################
+# Disable swap
+##############################
+sudo swapoff -a
+sudo sed -i '/swap/d' /etc/fstab
+
+##############################
+# Setup prerequisites
+##############################
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+sudo sysctl --system
+
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y containerd.io
+containerd config default |
+  sed -e "s/SystemdCgroup = false/SystemdCgroup = true/g" |
+  sed -e "s/registry.k8s.io\/pause:3.8/registry.k8s.io\/pause:3.10/g" |
+  sudo tee /etc/containerd/config.toml
+sudo systemctl restart containerd
+
+##############################
+# Install Kubernetes Packages
+##############################
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+
+sudo mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
+
+sudo mkdir -p /etc/default
+sudo apt-get install -y kubeadm=1.32.0-1.1 kubelet=1.32.0-1.1 kubectl=1.32.0-1.1
+echo "KUBELET_EXTRA_ARGS=--node-ip=$(hostname -I | awk '{print $2}')" | sudo tee /etc/default/kubelet
+sudo apt-mark hold kubeadm kubelet kubectl
+
+echo "$CONTROL_PLANE_IP k8scp" | sudo tee -a /etc/hosts

--- a/master.sh
+++ b/master.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+##############################
+# Install Kubernetes
+##############################
+
+# Initialize Kubernetes
+sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --apiserver-advertise-address=$CONTROL_PLANE_IP --control-plane-endpoint="k8scp:6443" --upload-certs
+sudo kubeadm token create --print-join-command > /vagrant/joincluster.sh
+
+# Configure kubectl
+mkdir -p /home/vagrant/.kube
+sudo cp -f /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+sudo chown vagrant:vagrant /home/vagrant/.kube/config
+
+# Enable kubectl completion
+sudo apt-get update
+sudo apt-get install -y bash-completion
+echo 'source <(kubectl completion bash)' >> ~vagrant/.bashrc
+echo 'alias k=kubectl' >> ~vagrant/.bashrc
+echo 'complete -F __start_kubectl k' >> ~vagrant/.bashrc
+
+# Install Helm
+sudo snap install helm --classic
+sleep 5 # Wait for helm to install
+
+# Install Cilium
+export PATH=/snap/bin:$PATH
+export KUBECONFIG=/home/vagrant/.kube/config
+helm repo add cilium https://helm.cilium.io/
+helm install cilium cilium/cilium --namespace kube-system --version 1.17.2

--- a/worker.sh
+++ b/worker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Join Kubernetes cluster
+bash /vagrant/joincluster.sh


### PR DESCRIPTION
### Kubernetes Lab: Local Multi-Node Cluster with Vagrant & VirtualBox

This pull request introduces a complete setup for a local multi-node Kubernetes cluster, ideal for learning, development, and certification preparation (CKA/CKAD). Key features and changes include:

- **Vagrantfile**: Automates the creation of one control plane and two worker nodes using Ubuntu 24.04 LTS, with port forwarding for the Kubernetes API.
- **Provisioning Scripts**:
  - `common.sh`: Installs containerd, disables swap, configures sysctl, and installs Kubernetes components (kubeadm, kubelet, kubectl).
  - `master.sh`: Initializes the control plane, sets up kubectl, installs Helm, and deploys Cilium CNI.
  - `worker.sh`: Joins worker nodes to the cluster using a generated join script.
- **.gitignore**: Ignores Vagrant and generated join scripts.
- **README.md**: Comprehensive documentation for setup, usage, cluster details, troubleshooting, and contributing.

**Cluster highlights:**
- Kubernetes 1.32.0, Cilium CNI 1.17.2, Helm pre-installed
- Control plane and two worker nodes, each with dedicated resources
- Simple commands for starting, stopping, and destroying the cluster
